### PR TITLE
tabs: getActiveIndex方法中this.$children可能获取不完整

### DIFF
--- a/src/tabs/tabs.vue
+++ b/src/tabs/tabs.vue
@@ -54,7 +54,9 @@ export default {
   watch: {
     value (val, oldVal) {
       if (val === oldVal) return
-      this.setTabLightStyle()
+      this.$nextTick(function () {
+        this.setTabLightStyle()
+      })
     }
   }
 }


### PR DESCRIPTION
需要动态设置tabs的元素时，getActiveIndex里面this.$children应该在dom更新完后才去获取，否则会不完整。