### PR TITLE
fix: closing tag of slot in cardHeader.vue

### DIFF
--- a/src/card/cardHeader.vue
+++ b/src/card/cardHeader.vue
@@ -9,7 +9,7 @@
       {{subTitle}}
     </div>
   </div>
-  <slot><slot>
+  <slot></slot>
 </div>
 </template>
 


### PR DESCRIPTION
fix closing tag of the default `<slot>`