### PR TITLE
Update td.vue

### DIFF
--- a/src/table/td.vue
+++ b/src/table/td.vue
@@ -39,6 +39,7 @@ export default {
   text-align: left;
   font-size: 13px;
   white-space: nowrap;
+  overflow: hidden;
   text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
使用text-overflow时， overflow 需要设置成除 visible 以外的属性，否则当文本超出表格限制是，不能正确显示省略符号