### PR TITLE
Use the Vue instance passed to install()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import './styles/base.less'
-import Vue from 'vue'
 import {retina} from './utils'
 import icon from './icon'
 import backTop from './backTop'
@@ -110,7 +109,7 @@ const components = {
   pagination
 }
 
-const install = function () {
+const install = function (Vue) {
   Object.keys(components).forEach((key) => {
     Vue.component(components[key].name, components[key])
   })


### PR DESCRIPTION
In `src/index.js`, the `install` function installs the components to the local `Vue` instance imported at the top of the file. This will cause calling `Vue.use` with the install function in the pre-compiled `dist/muse-ui.js` to silently fail and the components not being installed. This results in the following error when trying to use a component:

```
Unknown custom element: <mu-appbar> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
```

---

This pull request fixes this error by calling `component` of the Vue instance passed to the function as is recommended in the *[Writing a Plugin](https://vuejs.org/v2/guide/plugins.html)* (*[开发插件](https://cn.vuejs.org/v2/guide/plugins.html)*) guide.