### PR TITLE
picker: don't shrink items to support custom the item width

### DIFF
--- a/src/picker/picker-slot.vue
+++ b/src/picker/picker-slot.vue
@@ -150,7 +150,6 @@ export default {
 <style lang="less">
 @import "../styles/import.less";
 .mu-picker-slot{
-  .flex-shrink(1);
   font-size: 18px;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
Currently there is a inconsistence on Android 4.3 OS from the modern browsers for Picker. In my honestly opinion, here set flex-shrink seems to have items to be filled to the parent container element.

However sometimes we need to get items to be a customized width like 20%, it works on modern browsers seamlessly, but not at Android 4.3's WebView container, where only `-webkit-box` are supported, then the less function `.flex-shrink()` would set `-webkit-flex` to some number.

By another way, I found the less function `.flex-shrink()` also has an inconsistence: which adds `-webkit-box-flex` and `-ms-box-flex` but not set for `flex` and `-webkit-flex`, I guess that's the reason the items in flex/flexbox mode doesn't get filled.

/cc @myronliu347 