### PR TITLE
textField: fix display both value and label text when input type is number

### DIFF
--- a/src/textField/textField.vue
+++ b/src/textField/textField.vue
@@ -164,6 +164,9 @@ export default {
     },
     handleBlur (event) {
       this.isFocused = false
+      if (!this.inputValue) {
+        this.$refs.input.value = ''
+      }
       this.$emit('blur', event)
     },
     handleInput (val) {


### PR DESCRIPTION
input type 为 number 的时候，输入 e - 等字符导致 inputvalue 不合法的时候，blur 状态下会导致 label 和 value 同时显示。