### PR TITLE
去抖动

### DIFF
--- a/src/refreshControl/refreshControl.vue
+++ b/src/refreshControl/refreshControl.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mu-refresh-control" :style="refreshStyle" :class="refreshClass">
+  <div class="mu-refresh-control" :style="refreshStyle" :class="refreshClass"  v-show="y>5">
     <svg v-show="!refreshing && draging" viewBox="0 0 24 24" class="mu-refresh-svg-icon" :style="circularStyle">
       <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/>
     </svg>


### PR DESCRIPTION
在组件上部没有 overflow:hide 隐藏的情况下，只要点击 trigger指向的目标就会显示白色圆形
加一个 y>5 解决此问题。

e.g.
图片中显示的时 trigger 目标，绿色是padding范围。
由于我将 trigger 目标上部分指定了 padding，导致会显示出 这个白色圆形。
![](https://s3.amazonaws.com/drp.io/files/w33/SJgjPkyuW/QQ%E6%88%AA%E5%9B%BE20170814170341.png)