### PR TITLE
Update manager.js

### DIFF
--- a/src/internal/popup/manager.js
+++ b/src/internal/popup/manager.js
@@ -79,10 +79,14 @@ const PopupManager = {
 
   changeOverlayStyle () {
     const instance = this.instances[this.instances.length - 1]
-    if (!this.overlay || this.instances.length === 0 || !instance.overlay) return
-    this.overlay.color = instance.overlayColor
-    this.overlay.opacity = instance.overlayOpacity
-    this.overlay.zIndex = instance.overlayZIndex
+    if (!this.overlay || this.instances.length === 0 ) return
+    if(instance.overlay){
+      this.overlay.color = instance.overlayColor
+      this.overlay.opacity = instance.overlayOpacity
+      this.overlay.zIndex = instance.overlayZIndex
+    }else{
+      this.closeOverlay();
+    }
   },
 
   handleOverlayClick () {


### PR DESCRIPTION
在有多个popup,且第一个overlay为false时,关闭最上层popup, overlay状态不为预期.  
原因：82行 如果instance.overlay === false ,直接结束changeOverlayStyle方法. 可overlay 状态并没有复原.