### PR TITLE
picker: 固定 picker 的 item 高度

### DIFF
--- a/src/picker/picker-slot.vue
+++ b/src/picker/picker-slot.vue
@@ -167,6 +167,7 @@ export default {
   backface-visibility: hidden;
 }
 .mu-picker-item{
+  height: 36px;
   line-height: 36px;
   padding: 0 10px;
   font-size: 20px;


### PR DESCRIPTION
如果只依赖 line-height 在小米等手机上可以改变浏览器的字体大小，会导致位置错乱。
![ae27fc90-cb3c-4e15-8d5b-aaa98612d47d](https://user-images.githubusercontent.com/6724396/30773088-f470a426-a09b-11e7-94ff-a84fa552cd00.png)

