### PR TITLE
backTop: fix backTop doesn't work and import lodash/throttle

### DIFF
--- a/src/backTop/assist.js
+++ b/src/backTop/assist.js
@@ -1,6 +1,12 @@
 export const backTop = (durations, callback = undefined) => {
-  const dom = document.getElementsByTagName('body')[0]
+  let dom
+  if (document.documentElement.scrollTop) {
+    dom = document.documentElement
+  } else {
+    dom = document.body
+  }
   const scrollTop = dom.scrollTop
+
   for (var i = 60; i >= 0; i--) {
     setTimeout((i => {
       return () => {

--- a/src/backTop/backTop.vue
+++ b/src/backTop/backTop.vue
@@ -10,6 +10,7 @@
 <script>
 import {backTop} from './assist.js'
 import icon from '../icon'
+import throttle from 'lodash/throttle'
 
 export default {
   name: 'mu-back-top',
@@ -57,16 +58,18 @@ export default {
       backTop(this.durations, this.callBack)
     },
     scrollListener () {
-      this.backShow = document.getElementsByTagName('body')[0].scrollTop >= this.height
+      var top = document.documentElement.scrollTop || document.body.scrollTop
+      this.backShow = top >= this.height
     }
   },
   mounted () {
-    window.addEventListener('scroll', this.scrollListener, false)
-    window.addEventListener('resize', this.scrollListener, false)
+    this._scrollListener = throttle(this.scrollListener, 100)
+    window.addEventListener('scroll', this._scrollListener, false)
+    window.addEventListener('resize', this._scrollListener, false)
   },
   beforeDestroy () {
-    window.removeEventListener('scroll', this.handleScroll, false)
-    window.removeEventListener('resize', this.handleScroll, false)
+    window.removeEventListener('scroll', this._scrollListener, false)
+    window.removeEventListener('resize', this._scrollListener, false)
   }
 }
 </script>


### PR DESCRIPTION
解决: Mu-back-top 组件无法正常工作得情况，相关 issues #739  #776 

原因：document.getElementsByTagName('body')[0].scrollTop 在W3C标准下值为0，不会改变

使用
```javascript
    // this.backShow = document.getElementsByTagName('body')[0].scrollTop >= this.height
    var top = document.documentElement.scrollTop || document.body.scrollTop
    this.backShow = top >= this.height
```
另外，引入节流函数throttle，优化滚动性能
