### PR TITLE
fix: component circular.vue throws 'Do not use built-in or reserved HTML elements as component' #824

### DIFF
--- a/src/internal/circular.vue
+++ b/src/internal/circular.vue
@@ -17,7 +17,7 @@
 <script>
 import {getColor} from '../utils'
 export default {
-  name: 'circle',
+  name: 'circular',
   props: {
     size: {
       type: Number,


### PR DESCRIPTION
Rename `circular.vue` from 'circle' to 'circular'.