### PR TITLE
Update FormItem.js

### DIFF
--- a/ui/Form/FormItem.js
+++ b/ui/Form/FormItem.js
@@ -40,7 +40,7 @@ export default {
   },
   methods: {
     validate () {
-      if (!this.rules || this.rules.length === 0) return;
+      if (!this.rules || this.rules.length === 0) return true;
       for (let i = 0; i < this.rules.length; i++) {
         const rule = this.rules[i];
         if (!rule.validate(this.muForm.model[this.prop], this.muForm.model)) {


### PR DESCRIPTION
if (!this.rules || this.rules.length === 0) return;

这样会使没有  rules 标签的 item 始终返回 undefined 导致表单验证不成功

建议改为:
if (!this.rules || this.rules.length === 0) return ture;