### PR TITLE
Ripple: fix 修复 Pipple 点击波纹失效问题

### DIFF
--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -28,7 +28,8 @@ export default {
   render (h) {
     return h('transition', {
       props: {
-        name: 'mu-ripple'
+        name: 'mu-ripple',
+        appear: true
       }
     }, [
       h('div', {


### PR DESCRIPTION
修复：vue 版本 2.6.8 以上 Ripple 组件点击后波纹效果失效