### PR TITLE
fix: v-scroll directive event listener leak

### DIFF
--- a/src/internal/directives/scroll.js
+++ b/src/internal/directives/scroll.js
@@ -35,6 +35,5 @@ function unbind (el, binding) {
 export default {
   name: 'scroll',
   inserted: bindScroll,
-  update: bindScroll,
   unbind: unbind
 };


### PR DESCRIPTION
There's a heavy event listener leak when using `v-scroll` directive.

![image](https://user-images.githubusercontent.com/13914967/58623962-b1a38380-8301-11e9-97d9-7cff30d69a0b.png)

The performance profile was captured in https://muse-ui.org/#/zh-CN/directives . When the page scrolls, there's just tons of event listeners been attached, but none of them got removed.

https://github.com/museui/muse-ui/blob/master/src/internal/directives/scroll.js#L38

I think the `update` function in this directive was totally unnecessary, according to [Vue Custom Directive Guide](https://vuejs.org/v2/guide/custom-directive.html#Hook-Functions). 

To demonstrate this, there's a fiddle: https://jsfiddle.net/zgrxt69h/ . `update` was removed, and it still works fine.