### PR TITLE
DateInput: fix 修复在popover模式下选择年份月份时popover会关闭的问题

### DIFF
--- a/src/DateInput/DateInput.js
+++ b/src/DateInput/DateInput.js
@@ -262,7 +262,8 @@ export default {
         },
         ref: 'popover',
         on: {
-          close: this.closePicker
+          close: this.closePicker,
+          click: e => { e.stopPropagation() }
         }
       }, [this.createPicker(h)])
     ]);


### PR DESCRIPTION
选择年份月份后click事件会冒泡到外面导致popover被错误关闭
修复https://github.com/museui/muse-ui/issues/1395 https://github.com/museui/muse-ui/issues/1327