### PR TITLE
Popover: fix #1285 bug

### DIFF
--- a/src/internal/directives/scroll.js
+++ b/src/internal/directives/scroll.js
@@ -16,8 +16,12 @@ function bindScroll (el, binding) {
   const handleScroll = function (e) {
     callback(target, e);
   };
-  if (el._onScroll && target !== el._onScroll.target) unbind(el, binding);
 
+  if (el._onScroll && target !== el._onScroll.target) {
+    unbind(el, binding);
+  } else if (el._onScroll) {
+    return;
+  }
   target.addEventListener('scroll', handleScroll, options);
 
   el._onScroll = {


### PR DESCRIPTION
Hello!
My PR fixes memory leak errors that exist in components that use the Popover component with the Scroll directive.

Many event listeners were registered, but the target element did not change.
This problem we can see on https://muse-ui.org/#/en-US/select using Memory Chrome DevTools.