### PR TITLE
Tabs: fixes #1446

### DIFF
--- a/src/utils/translate.js
+++ b/src/utils/translate.js
@@ -74,7 +74,7 @@ var cancelTranslateElement = function (element) {
   if (element === null || element.style === null) return;
   var transformValue = element.style[transformProperty];
   if (transformValue) {
-    transformValue = transformValue.replace(/translate\(\s*(-?\d+(\.?\d+?)?)px,\s*(-?\d+(\.\d+)?)px\)\s*translateZ\(0px\)/g, '');
+    transformValue = transformValue.replace(/translate\(\s*(-?\d+(\.?\d+?)?)px(,\s*(-?\d+(\.\d+)?)px)*\)\s*translateZ\(0px\)/g, '');
     element.style[transformProperty] = transformValue;
   }
 };


### PR DESCRIPTION
#1446 

In Firefox, transformValue did not match the regex, which resulted in strings like translate(160px) translate(160px) leading to multiple translations. 

In Firefox, translate functions look like this: translate(160px)
In Chrome, for example, they look like this: translate(160px, 0px)